### PR TITLE
Add fixes for hvc1

### DIFF
--- a/src/mp4box/hev1.rs
+++ b/src/mp4box/hev1.rs
@@ -269,6 +269,12 @@ pub struct HvcCArray {
     pub nalus: Vec<HvcCArrayNalu>,
 }
 
+impl HvcCArray {
+    pub fn is_parameter_set(&self) -> bool {
+        self.nal_unit_type == VPS || self.nal_unit_type == SPS || self.nal_unit_type == PPS
+    }
+}
+
 impl<R: Read + Seek> ReadBox<&mut R> for HvcCBox {
     fn read_box(reader: &mut R, _size: u64) -> Result<Self> {
         let configuration_version = reader.read_u8()?;

--- a/src/mp4box/hev1.rs
+++ b/src/mp4box/hev1.rs
@@ -101,31 +101,38 @@ impl<R: Read + Seek> ReadBox<&mut R> for Hev1Box {
         let depth = reader.read_u16::<BigEndian>()?;
         reader.read_i16::<BigEndian>()?; // pre-defined
 
-        let header = BoxHeader::read(reader)?;
-        let BoxHeader { name, size: s } = header;
-        if s > size {
-            return Err(Error::InvalidData(
-                "hev1 box contains a box with a larger size than it",
-            ));
-        }
-        if name == BoxType::HvcCBox {
-            let hvcc = HvcCBox::read_box(reader, s)?;
+        let mut hvcc = None;
 
-            skip_bytes_to(reader, start + size)?;
-
-            Ok(Hev1Box {
-                data_reference_index,
-                width,
-                height,
-                horizresolution,
-                vertresolution,
-                frame_count,
-                depth,
-                hvcc,
-            })
-        } else {
-            Err(Error::InvalidData("hvcc not found"))
+        while reader.stream_position()? < start + size {
+            let header = BoxHeader::read(reader)?;
+            let BoxHeader { name, size: s } = header;
+            if s > size {
+                return Err(Error::InvalidData(
+                    "hev1 box contains a box with a larger size than it",
+                ));
+            }
+            if name == BoxType::HvcCBox {
+                hvcc = Some(HvcCBox::read_box(reader, s)?);
+            } else {
+                skip_box(reader, s)?;
+            }
         }
+        let Some(hvcc) = hvcc else {
+            return Err(Error::InvalidData("hvcc not found"));
+        };
+
+        skip_bytes_to(reader, start + size)?;
+
+        Ok(Hev1Box {
+            data_reference_index,
+            width,
+            height,
+            horizresolution,
+            vertresolution,
+            frame_count,
+            depth,
+            hvcc,
+        })
     }
 }
 

--- a/src/mp4box/stsd.rs
+++ b/src/mp4box/stsd.rs
@@ -41,6 +41,8 @@ impl StsdBox {
             size += avc1.box_size();
         } else if let Some(ref hev1) = self.hev1 {
             size += hev1.box_size();
+        } else if let Some(ref hvc1) = self.hvc1 {
+            size += hvc1.box_size();
         } else if let Some(ref vp09) = self.vp09 {
             size += vp09.box_size();
         } else if let Some(ref mp4a) = self.mp4a {
@@ -145,6 +147,8 @@ impl<W: Write> WriteBox<&mut W> for StsdBox {
             avc1.write_box(writer)?;
         } else if let Some(ref hev1) = self.hev1 {
             hev1.write_box(writer)?;
+        } else if let Some(ref hvc1) = self.hvc1 {
+            hvc1.write_box(writer)?;
         } else if let Some(ref vp09) = self.vp09 {
             vp09.write_box(writer)?;
         } else if let Some(ref mp4a) = self.mp4a {


### PR DESCRIPTION
-Fixed stsd `write_box()` to include hvc1.
-hev1 and hvc1 are the same except for the `completeness` flag for parameter sets.
-Also skip unknown boxes in hev1. None of my sample files have this, but we might as well keep hev1/hvc1 as similar as possible.

This works with all of my sample hvc1 and hev1 files.
